### PR TITLE
Allow user to copy script tags also

### DIFF
--- a/ngClipboard.js
+++ b/ngClipboard.js
@@ -4,7 +4,7 @@ angular.module('ngClipboard', [])
         return {
             toClipboard: function(element){
 
-            var copyElement = angular.element('<span id="ngClipboardCopyId">'+element+'</span>');
+            var copyElement = angular.element('<textarea id="ngClipboardCopyId">'+element+'</textarea>');
             var body = $document.find('body').eq(0);
             body.append($compile(copyElement)($rootScope));
             


### PR DESCRIPTION
Hey there,
Using `textarea` instead of `span` will allow us to use script tags in our copy string as below:
```javascript
<script type="text/javascript">
    !( function( w, d ) {
        'use strict';
        var awesome = 'ngClipboard';
        console.log('Something awesome: ');
        console.log(w);
        console.log(d);
    })( this, document );
</script>
```